### PR TITLE
[AV-1415] Limit result caching to child exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,11 @@ Note that `associated_data` will be returned as a hash, with the data returned b
 ###### Approach 2 - Custom Room Exporter
 As the exporter is responsible for fetching data, it can store it in such a way that it is easier to use by a parent exporter. For example, if this `RoomExporter` is only used as an associated exporter of the `HouseCsvExporter`, we know that the parent only wants a pipe delimited list of room names.
 
-To provide this, the `RoomExporter` needs to overwrite the `save_entry` method. As with `on_entry`, this method is called for each entry found by the exporter. Unlike `on_entry`, `save_entry` is not an abstract method, and so provides default behaviour. By default, `save_entry` just builds an array of entries, and is defined as:
+To provide this, the `RoomExporter` needs to overwrite the `save_entry` method. As with `on_entry`, this method is called for each entry found by the exporter. Unlike `on_entry`, `save_entry` does provide some default behaviour. By default, `save_entry` just builds an array of entries when the exporter is run as a child, and is defined as:
 
     def save_entry(export_data, associated_data=nil)
+      return unless child_export?
+
       @export_entries ||= []
       @export_entries << export_data
     end

--- a/app/controllers/exportling/exports_controller.rb
+++ b/app/controllers/exportling/exports_controller.rb
@@ -75,6 +75,12 @@ class Exportling::ExportsController < Exportling::ApplicationController
 
   def authorize_new_export
     return unless using_pundit
+
+    if @export.authorize_on_class.nil?
+      msg = "You must pass a class name to authorize_on_class in your exporter"
+      raise ArgumentError, msg
+    end
+
     authorize(@export.authorize_on_class, :export?)
   end
 

--- a/app/workers/exportling/exporter.rb
+++ b/app/workers/exportling/exporter.rb
@@ -15,10 +15,6 @@ module Exportling
     include ChildExporterMethods
     include CommonMethods
 
-    def initialize
-      @export_entries ||= []
-    end
-
     # Worker Methods ============================================================
     # Shortcut to instance peform method
     def self.perform(export_id, options = {})
@@ -37,7 +33,7 @@ module Exportling
       @export.set_processing!
 
       # Run the rest of the export as if we are a root or child exporter, depending on perform arguments
-      if @child
+      if child_export?
         perform_as_child
       else
         perform_as_root
@@ -87,10 +83,19 @@ module Exportling
       end
     end
 
+    # Is this exporter running as a child of another exporter?
+    def child_export?
+      !!@child
+    end
+
     # Caches the results of each entry
-    # By default, just saves the entry in an array
-    # Often overwritten in the extending class
+    # By default, just saves the entry in an array if this exporter is running
+    # as a child.
+    # May be overwritten in the extending class
     def save_entry(export_data, associated_data = nil)
+      return unless child_export?
+
+      @export_entries ||= []
       @export_entries << export_data
     end
 

--- a/exportling.gemspec
+++ b/exportling.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'draper', '~> 2.1.0'
   s.add_dependency 'ransack'
   s.add_dependency 'hashie', '~> 3.2.0'
-  s.add_dependency 'hashie_rails', '~> 0.0.1'
+  s.add_dependency 'hashie-forbidden_attributes', '~> 0.1.1'
   s.add_dependency 'fog', '~> 1.24.0'
 
   s.add_development_dependency "rspec-rails", '~> 3.2.1'

--- a/lib/exportling/engine.rb
+++ b/lib/exportling/engine.rb
@@ -9,7 +9,7 @@ module Exportling
     require 'hash_to_hidden_fields'
     require 'draper'
     require 'hashie'
-    require 'hashie_rails'
+    require 'hashie-forbidden_attributes'
 
     # Make sure our query objects are required
     config.to_prepare do

--- a/lib/exportling/version.rb
+++ b/lib/exportling/version.rb
@@ -1,3 +1,3 @@
 module Exportling
-  VERSION = '0.2.12'
+  VERSION = '0.3.0'
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -19,6 +19,8 @@ module Dummy
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+
+    config.active_record.raise_in_transactional_callbacks = true
   end
 end
 

--- a/spec/workers/exportling/exporter_spec.rb
+++ b/spec/workers/exportling/exporter_spec.rb
@@ -83,7 +83,7 @@ describe Exportling::Exporter do
     let(:export)                { create(:export, params: export_params) }
     let(:exporter)              { HouseCsvExporter.new }
 
-    before  { exporter.perform(export, params: options_params) }
+    before  { exporter.perform(export.id, params: options_params) }
     subject { exporter.query_params }
     context 'export.params empty' do
       let(:export_params) { {} }
@@ -156,14 +156,29 @@ describe Exportling::Exporter do
     subject { exporter.save_entry(entry) }
 
     describe 'default behaviour' do
-      it 'inits @default_entries' do
-        subject
-        expect(exporter.instance_variable_get(:@export_entries)).to be_a(Array)
+      before { allow(exporter).to receive(:child_export?) { is_child } }
+
+      context 'for a root exporter' do
+        let(:is_child) { false }
+
+        it 'does not init @default_entries' do
+          subject
+          expect(exporter.instance_variable_get(:@export_entries)).to be_nil
+        end
       end
 
-      it 'saves the entry to @default_entries' do
-        subject
-        expect(exporter.instance_variable_get(:@export_entries)).to include(entry)
+      context 'for a child exporter' do
+        let(:is_child) { true }
+
+        it 'inits @default_entries' do
+          subject
+          expect(exporter.instance_variable_get(:@export_entries)).to be_a(Array)
+        end
+
+        it 'saves the entry to @default_entries' do
+          subject
+          expect(exporter.instance_variable_get(:@export_entries)).to include(entry)
+        end
       end
     end
   end


### PR DESCRIPTION
Stop adding entries to `@export_entries` for root exporters. Keeps adding for child exporters, as we need to be able to pass the collection back to the parent exporter.

If the developer needs to cache these results on a root exporter, they can overwrite `save_entry` as before.

Bumped a minor version, as users may be relying on the automatic caching of these results.