### PR TITLE
[AV-2858] Use export file type for extension of exported file instead of hardcoded .csv

### DIFF
--- a/app/workers/exportling/exporter/root_exporter_methods.rb
+++ b/app/workers/exportling/exporter/root_exporter_methods.rb
@@ -4,7 +4,7 @@ module Exportling
     # Top level export
     # This is the export method that will be called for the entry Exporter
     def perform_as_root
-      @temp_export_file = Tempfile.new(['export', '.csv'])
+      @temp_export_file = Tempfile.new(['export', ".#{@export.file_type}"])
       on_start(@temp_export_file)
 
       find_each do |export_data|

--- a/lib/exportling/version.rb
+++ b/lib/exportling/version.rb
@@ -1,3 +1,3 @@
 module Exportling
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end

--- a/spec/workers/exportling/exporter/root_exporter_methods_spec.rb
+++ b/spec/workers/exportling/exporter/root_exporter_methods_spec.rb
@@ -37,6 +37,15 @@ describe Exportling::Exporter::RootExporterMethods do
         end
       end
     end
+
+    describe 'export file' do
+      let(:export) { create(:export, klass: exporter_class.to_s, file_type: 'pdf', status: 'created') }
+
+      it 'has correct file extension' do
+        subject
+        expect(export.output.path).to end_with('.pdf')
+      end
+    end
   end
 
   describe 'finish_root_export' do


### PR DESCRIPTION
https://jobready.atlassian.net/browse/AV-2858

Allows pdfs to be downloaded correctly in AVETARS.