### PR TITLE
NEP-2363 Upgrade kaminari gem to use latest version 0.16.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Gemfile.lock
 *.gem
 sidekiq.pid
 coverage
+.idea/

--- a/exportling.gemspec
+++ b/exportling.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'carrierwave', '~> 0.10.0'
   s.add_dependency 'carrierwave-aws'
   s.add_dependency 'sidekiq', '>= 2.17.0'
-  s.add_dependency 'kaminari', '~> 0.15.1'
+  s.add_dependency 'kaminari', '~> 0.16'
   s.add_dependency 'hash_to_hidden_fields', '~> 2.0.1'
   s.add_dependency 'draper', '~> 2.1.0'
   s.add_dependency 'ransack'

--- a/lib/exportling/version.rb
+++ b/lib/exportling/version.rb
@@ -1,3 +1,3 @@
 module Exportling
-  VERSION = '0.4.4'
+  VERSION = '0.4.5'
 end


### PR DESCRIPTION
In order to use Exportling gem in Neptune newest version kaminari have to be used.