### PR TITLE
Export File Name Suffix Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Configure Exportling in your application
     # E.g. If using devise, this would be set to
     Exportling.export_owner_method = :current_user
 
+    # (Optional) Set a suffix that should be applied to export file names
+    Exportling.export_file_name_suffix = "suffix"
+
     # (Required) Set the S3 Bucket Name (used to set fog directory)
     #This option will either take a block which returns the S3 Bucket name
     Exportling.s3_bucket_name = -> {"#{Apartment::Tenant.current_tenant.downcase.gsub(/\s/, '_')}-exportling-#{Rails.env}" }

--- a/app/models/exportling/export.rb
+++ b/app/models/exportling/export.rb
@@ -50,7 +50,8 @@ class Exportling::Export < ActiveRecord::Base
   end
 
   def file_name
-    "#{id}_#{name.parameterize}_#{created_at.strftime('%Y-%m-%d')}.#{file_type}"
+    "#{id}_#{name.parameterize}_#{created_at.strftime('%Y-%m-%d')}" +
+    Exportling.export_file_name_suffix + ".#{file_type}"
   end
 
   def set_processing!

--- a/app/workers/exportling/exporter/root_exporter_methods.rb
+++ b/app/workers/exportling/exporter/root_exporter_methods.rb
@@ -4,7 +4,10 @@ module Exportling
     # Top level export
     # This is the export method that will be called for the entry Exporter
     def perform_as_root
-      @temp_export_file = Tempfile.new(['export', ".#{@export.file_type}"])
+      @temp_export_file = Tempfile.new([
+        "export#{Exportling.export_file_name_suffix}", ".#{@export.file_type}"
+      ])
+
       on_start(@temp_export_file)
 
       find_each do |export_data|

--- a/exportling.gemspec
+++ b/exportling.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'ransack'
   s.add_dependency 'strata', '~> 0.6'
 
-  s.add_development_dependency "rspec-rails", '~> 3.2.1'
+  s.add_development_dependency "rspec-rails", '~> 3.5.2'
   s.add_development_dependency 'factory_girl_rails', '~> 4.4.1'
   s.add_development_dependency 'database_cleaner', '~> 1.2.0'
   s.add_development_dependency "byebug", '~> 2.7.0'

--- a/lib/exportling.rb
+++ b/lib/exportling.rb
@@ -2,7 +2,7 @@ require "exportling/engine"
 
 module Exportling
   mattr_accessor :export_owner_class, :export_owner_method,
-    :base_storage_directory, :raise_on_fail,
+    :export_file_name_suffix, :base_storage_directory, :raise_on_fail,
     :authorization_mechanism, :s3_bucket_name
 
   # Allow the base application to set the owner of the export
@@ -13,6 +13,12 @@ module Exportling
   # Allow base application to define the method to find the current owner
   def self.export_owner_method
     @@export_owner_method
+  end
+
+  # Allow the base application to provide a suffix that should be applied to
+  # export file names
+  def self.export_file_name_suffix
+    @@export_file_name_suffix || ""
   end
 
   # When an export fails, should the exporter raise the error

--- a/lib/exportling/version.rb
+++ b/lib/exportling/version.rb
@@ -1,3 +1,3 @@
 module Exportling
-  VERSION = '0.4.5'
+  VERSION = '0.4.6'
 end

--- a/spec/models/exportling/export_spec.rb
+++ b/spec/models/exportling/export_spec.rb
@@ -79,10 +79,17 @@ describe Exportling::Export do
   describe 'file_name' do
     let(:created_time)        { Time.zone.parse('Feb 1, 2009') }
     let(:export_id)           { export.id }
-    let(:expected_file_name)  { "#{export_id}_houses_2009-02-01.csv" }
 
     before  { export.update_column(:created_at, created_time) }
-    specify { expect(export.file_name).to eq expected_file_name }
+
+    context "given no export_file_name_suffix is set" do
+      specify { expect(export.file_name).to eq "#{export_id}_houses_2009-02-01.csv" }
+    end
+
+    context "given an export_file_name_suffix is set" do
+      before  { Exportling.export_file_name_suffix = "[DLM=Sensitive]" }
+      specify { expect(export.file_name).to eq "#{export_id}_houses_2009-02-01[DLM=Sensitive].csv" }
+    end
   end
 
   describe 'status changes' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,6 @@
 require 'simplecov'
 SimpleCov.start
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
-
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
   SimpleCov::Formatter::HTMLFormatter
 ]


### PR DESCRIPTION
Adds support for an optional suffix to be applied to export file names.

Version `1.0` of the `codeclimate-test-reporter` gem introduced breaking
changes to the way the test reporter is meant to be executed.

This removes the now deprecated call to
`CodeClimate::TestReporter.start` and will move the responsibility of
Code Climate reporting to Buildkite.

See [changelog](https://github.com/codeclimate/ruby-test-reporter/blob/master/CHANGELOG.md#v100-2016-11-03) for more details.